### PR TITLE
修复查看定义时候的 crash 问题

### DIFF
--- a/luahelper-lsp/langserver/check/check_lsp_define.go
+++ b/luahelper-lsp/langserver/check/check_lsp_define.go
@@ -426,8 +426,11 @@ func (a *AllProject) FindVarDefine(strFile string, varStruct *common.DefineVarSt
 		oldSymbol = a.createAnnotateSymbol(findStrName, findVar)
 	}
 	//调用链中没有函数，走这里
-	symList = a.getDeepVarList(oldSymbol, varStruct, comParam)
-	return oldSymbol, symList
+	if oldSymbol != nil {
+		symList = a.getDeepVarList(oldSymbol, varStruct, comParam)
+		return oldSymbol, symList
+	}
+	return nil, nil
 }
 
 // AnnotateTypeDefine 注解类型代码补全


### PR DESCRIPTION
修复查看定义时候的 crash 问题，比如查看下面找不到的库 lib_not_found 导出的 fieldName 导致的 crash，local lib = require("lib_not_found").fieldName