### PR TITLE
当方法里 local 与 self 同名时，修正 self 指向正确的位置，通过 scope 寻找合适的 variable 位置

### DIFF
--- a/luahelper-lsp/langserver/check/check_lsp_define.go
+++ b/luahelper-lsp/langserver/check/check_lsp_define.go
@@ -303,11 +303,7 @@ func (a *AllProject) getVarCommonFuncParam(strFile string, varStruct *common.Def
 	}
 
 	// 5)冒号 函数，self语法进行转换
-	if common.ChangeFuncSelfToReferVar(minFunc, varStruct) {
-		minFunc = minFunc.GetParent()
-		varStruct.PosLine = minFunc.Loc.StartLine
-		varStruct.PosCh = minFunc.Loc.StartColumn
-	}
+	common.ChangeFuncSelfToReferVar(minFunc, varStruct)
 
 	// 6) 判断是否找的在table的定义处, 如果是不缺前面的定义
 	if len(varStruct.StrVec) == 1 && !varStruct.BracketsFlag {

--- a/luahelper-lsp/langserver/check/common/util.go
+++ b/luahelper-lsp/langserver/check/common/util.go
@@ -1030,21 +1030,21 @@ func GetExpLoc(node ast.Exp) (loc lexer.Location) {
 // function a:test1()
 //	 self.b = 3  -- 传人的为self.b
 // end
-func ChangeFuncSelfToReferVar(fi *FuncInfo, varStruct *DefineVarStruct) bool {
+func ChangeFuncSelfToReferVar(fi *FuncInfo, varStruct *DefineVarStruct) {
 	firstColonFunc := fi.FindFirstColonFunc()
 	if firstColonFunc == nil {
-		return false
+		return
 	}
 	if !firstColonFunc.IsColon {
-		return false
+		return
 	}
 
 	if firstColonFunc.RelateVar == nil {
-		return false
+		return
 	}
 
 	if len(varStruct.StrVec) < 1 {
-		return false
+		return
 	}
 
 	if varStruct.StrVec[0] == "self" {
@@ -1057,9 +1057,13 @@ func ChangeFuncSelfToReferVar(fi *FuncInfo, varStruct *DefineVarStruct) bool {
 			strArray = append(strArray, varStruct.StrVec[1:]...)
 			varStruct.StrVec = strArray
 		}
-		return true
+		// 通过 scope 寻找 table name 定义的位置，肯定在 ':' 函数之前
+		relateVar, _ := firstColonFunc.MainScope.FindLocVar(varStruct.StrVec[0], firstColonFunc.Loc)
+		if relateVar != nil {
+			varStruct.PosLine = relateVar.Loc.StartLine
+			varStruct.PosCh = relateVar.Loc.StartColumn
+		}
 	}
-	return false
 }
 
 // ChangeSelfToVarComplete 冒号 函数，self语法进行转换


### PR DESCRIPTION
修正下面这样的场景，hover 或 define  foo:test() 中的 self:bar() 时，无法定位到 foo:bar()

```lua
local AnyLib = require("anylib")
local foo = {}

function foo:test()
    local foo = {}
    self:bar()
end

function foo:bar()
end
```