### PR TITLE
todo highlight on multi dashes

### DIFF
--- a/luahelper-vscode/syntaxes/lua.json
+++ b/luahelper-vscode/syntaxes/lua.json
@@ -365,7 +365,7 @@
         "comment": {
             "patterns": [
                 {
-                    "match": "(-- *todo\\b)|(-- *TODO\\b)",
+                    "match": "(--[- ]*)(todo|TODO)(\\b)",
                     "name": "keyword.todo.lua"
                 },
                 {


### PR DESCRIPTION
The change made within the json file makes the todo work on comments with multible dashes like this,

```lua
-- todo: some things
--- todo: these things
---------------                          todo: or these things
```