### PR TITLE
Fix #156: 添加调试项时信息缺失

### DIFF
--- a/luahelper-vscode/package.json
+++ b/luahelper-vscode/package.json
@@ -277,7 +277,7 @@
                             "request": "launch",
                             "name": "LuaHelper-Attach",
                             "description": "通用模式,通常调试项目请选择此模式",
-                            "cwd": "${workspaceFolder}",
+                            "cwd": "^\"${workspaceFolder}\"",
                             "luaFileExtension": "",
                             "connectionPort": 8818,
                             "stopOnEntry": true,


### PR DESCRIPTION
添加调试选项时, `${workspaceFolder}` 字符串被替换为空字符串.

```json
"configurationSnippets": [
                    {
                        "label": "LuaHelper: Attach",
                        "description": "LuaHelper debug attach by socket",
                        "body": {
                            "type": "LuaHelper-Debug",
                            "request": "launch",
                            "name": "LuaHelper-Attach",
                            "description": "通用模式,通常调试项目请选择此模式",
                            "cwd": "${workspaceFolder}",
                            "luaFileExtension": "",
                            "connectionPort": 8818,
                            "stopOnEntry": true,
                            "useCHook": true,
                            "autoPathMode": true
                        }
                    }
             ]
```

其中`"cwd": "${workspaceFolder}",` 配置到 *launch.json* 前需要经过一次转换.

`body` 语法: https://code.visualstudio.com/docs/languages/json#_json-schemas-settings

> body is the JSON object that is stringified and inserted when the completion is selected by the user. [Snippet syntax](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax) can be used inside strings literals to define tabstops, placeholders, and variables. If a string starts with ^, the string content will be inserted as-is, not stringified. You can use this to specify snippets for numbers and booleans.

应修改为: `"cwd": "^\"${workspaceFolder}\"",`