### PR TITLE
Fix #158 Linux下Tools.getLuaPathInExtension返回无效路径

### DIFF
--- a/luahelper-vscode/src/common/tools.ts
+++ b/luahelper-vscode/src/common/tools.ts
@@ -14,7 +14,7 @@ export class Tools {
     // 路径相关函数
     // 获取扩展中预置的lua文件位置
     public static getLuaPathInExtension() : string{
-        let luaPathInVSCodeExtension = this.VSCodeExtensionPath + "/Debugger/LuaPanda.lua";
+        let luaPathInVSCodeExtension = this.VSCodeExtensionPath + "/debugger/LuaPanda.lua";
         return luaPathInVSCodeExtension;
     }
 
@@ -24,13 +24,13 @@ export class Tools {
 
     // 获取扩展中预置的lua文件位置
     public static getClibPathInExtension() : string{
-        let ClibPathInVSCodeExtension = this.VSCodeExtensionPath + "/Debugger/debugger_lib/plugins/";
+        let ClibPathInVSCodeExtension = this.VSCodeExtensionPath + "/debugger/debugger_lib/plugins/";
         return ClibPathInVSCodeExtension;
     }
 
     // 
     public static GetClibPathStr(str:string) : string{
-        let ClibPathInVSCodeExtension = str + "/Debugger/debugger_lib/plugins/";
+        let ClibPathInVSCodeExtension = str + "/debugger/debugger_lib/plugins/";
         return ClibPathInVSCodeExtension;
     }
 


### PR DESCRIPTION
定制LuaHelper时获取LuaPanda.lua路径时报错, 
![image](https://user-images.githubusercontent.com/12892734/224359208-5e41c934-ab29-4dc8-a24c-5e75eacee44f.png)

不同于luapanda将LuaPanda和clib放在`~/.vscode-server/extensions/luapanda-3.2.6/Debugger`下, LuaHelper改变了存放路径为`~/.vscode-server/extensions/qingteng.luahelper-0.2.21/debugger`, 由于linux下路径大小写敏感, 导致接口Tools.getLuaPathInExtension返回无效路径.


